### PR TITLE
Sonderzeichen im identifier ersetzen

### DIFF
--- a/src/exercise/grades/submission.rs
+++ b/src/exercise/grades/submission.rs
@@ -72,7 +72,7 @@ impl GradeSubmission {
         } else {
             whatever!("This submission style is not yet supported");
         };
-            let identifier  = identifier.replace("Ä", "Ae").replace("ä", "ae").replace("Ü","Ue").replace("ü","ue").replace("Ö","Oe").replace("ö","oe").replace("ß","ss");
+        let identifier  = identifier.replace("Ä", "Ae").replace("ä", "ae").replace("Ü","Ue").replace("ü","ue").replace("Ö","Oe").replace("ö","oe").replace("ß","ss");
 
         let feedback_querypath = element
             .select(dropdown_action_selector)

--- a/src/exercise/grades/submission.rs
+++ b/src/exercise/grades/submission.rs
@@ -72,6 +72,7 @@ impl GradeSubmission {
         } else {
             whatever!("This submission style is not yet supported");
         };
+            let identifier  = identifier.replace("Ä", "Ae").replace("ä", "ae").replace("Ü","Ue").replace("ü","ue").replace("Ö","Oe").replace("ö","oe").replace("ß","ss");
 
         let feedback_querypath = element
             .select(dropdown_action_selector)


### PR DESCRIPTION
Sonderzeichen in den Namen der Teilnehmer werden in den Feedback Ordnern ersetzt aber nicht in der Ilias UI. Deshalb schlage ich vor sie an dieser Stelle zu ersetzen, da sonst die bewerten Abgaben fürs feedback nicht gefunden werden.